### PR TITLE
Support lucene search

### DIFF
--- a/sequel/lib/criteriaProcessor.js
+++ b/sequel/lib/criteriaProcessor.js
@@ -608,7 +608,20 @@ CriteriaProcessor.prototype.prepareCriterion = function prepareCriterion(key, va
       }
 
       break;
-
+      
+    case 'lucene':
+      
+      comparator = 'LUCENE';
+      if(this.parameterized) {
+        this.values.push('' + value);
+        str = comparator + ' ' + ':param' + this.paramCount;
+      }
+      else {
+        str = comparator + ' ' + utils.escapeName(value, '"');
+      }
+      
+      break;
+      
     case 'contains':
 
       if(this.caseSensitive) {


### PR DESCRIPTION
From 2.0 OrientDB [supports lucene indexes](http://orientdb.com/docs/last/Full-Text-Index.html). While their creation is not supported by `sails-orientdb`, they can be easily created manually. This PR gives the option to use lucene queries in the query builder. The only difference is using the keyword `LUCENE` instad of `CONTAINSTEXT`, and that they are ever more useful and flexible. 
